### PR TITLE
removing typing file before re-generating

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -44,6 +44,10 @@ const compileFiles = Object.values(federationConfig.exposes);
 const outFile = path.resolve(outputDir, `${federationConfig.name}.d.ts`);
 
 try {
+    if (fs.existsSync(outFile)) {
+        fs.unlinkSync(outFile);
+    }
+
     // write the typings file
     const program = ts.createProgram(compileFiles, {
         outFile,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pixability-ui/federated-types",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "share typings for your federated typescript packages around your mono-repo",
     "main": "cli.js",
     "scripts": {


### PR DESCRIPTION
This resolves an issue where the package name was being duplicated on successive runs.