### PR TITLE
bugfix/intra-package-imports

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -60,14 +60,23 @@ try {
 
     program.emit();
 
-    typing = fs.readFileSync(outFile, { encoding: 'utf8', flag: 'r' });
+    let typing = fs.readFileSync(outFile, { encoding: 'utf8', flag: 'r' });
+
+    const moduleRegex = RegExp(/declare module "(.*)"/, 'g');
+    const moduleNames = [];
+
+    while ((execResults = moduleRegex.exec(typing)) !== null) {
+        moduleNames.push(execResults[1]);
+    }
+
+    moduleNames.forEach((name) => {
+        const regex = RegExp(`"${name}`, 'g');
+        typing = typing.replace(regex, `"${federationConfig.name}/${name}`);
+    });
 
     console.log('writing typing file:', outFile);
 
-    fs.writeFileSync(
-        outFile,
-        typing.replace(/declare module \"/g, `declare module "${federationConfig.name}/`)
-    );
+    fs.writeFileSync(outFile, typing);
 
     // if we are writing to the node_modules/@types directory, add a package.json file
     if (outputDir.includes('node_modules/@types')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pixability-ui/federated-types",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "share typings for your federated typescript packages around your mono-repo",
     "main": "cli.js",
     "scripts": {


### PR DESCRIPTION
enhanced the replace logic with a regexp capture group to allow for replacing not just the declare statements, but also any intra-package import statements

this fixes an issue we saw where a default exported component was referencing an imported interface, and that interface was not being resolved correctly after we mutated the package name to conform to the federated scope.