### PR TITLE
feat: use custom config path with `--config` arg

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,11 @@ const outputDir = outDirArg
     ? path.resolve('./', outDirArg)
     : path.resolve(__dirname, '../../@types/__federated_types/');
 
+const configPathArg = getArg('--config');
+const configPath = configPathArg
+    ? path.resolve(configPathArg)
+    : null;
+
 const findFederationConfig = (base) => {
     let files = fs.readdirSync(base);
     let queue = [];
@@ -34,7 +39,13 @@ const findFederationConfig = (base) => {
     }
 };
 
-const federationConfigPath = findFederationConfig('./');
+if (configPath && !fs.existsSync(configPath)) {
+    console.error(`ERROR: Unable to find a provided config: ${configPath}`);
+    process.exit(1);
+}
+
+const federationConfigPath = configPath || findFederationConfig('./');
+
 
 if (federationConfigPath === undefined) {
     console.error(`ERROR: Unable to find a federation.config.json file in this package`);


### PR DESCRIPTION
I would like to propse new `--config` argument for passing custom path to the config

**To be**: `make-federated-types --config ./path/to/my/config.json --outputDir ../../my_types/`