### PR TITLE
✏️ Fix typo in package template file

### DIFF
--- a/typings.package.tmpl.json
+++ b/typings.package.tmpl.json
@@ -1,7 +1,7 @@
 {
     "name": "@types/__federated_types",
     "version": "0.0.1",
-    "description": "Placholder for federated typings",
+    "description": "Placeholder for federated typings",
     "license": "MIT",
     "main": "",
     "types": "index.d.ts"


### PR DESCRIPTION
Hey, 

Just a really minor one to be fair: `Placholder` vs `Placeholder`. 

_P.S.: Huge props for the package by the way, it helped a ton._